### PR TITLE
PART 3

### DIFF
--- a/PART 3
+++ b/PART 3
@@ -1,0 +1,51 @@
+# Install necessary packages (only run once)
+# !pip install aif360 numpy pandas matplotlib seaborn
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+from aif360.datasets import CompasDataset
+from aif360.metrics import BinaryLabelDatasetMetric, ClassificationMetric
+from aif360.algorithms.preprocessing import Reweighing
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+
+# Load the COMPAS dataset
+dataset = CompasDataset()
+
+# Define privileged and unprivileged groups based on race
+privileged_groups = [{'race': 1}]  # Caucasian
+unprivileged_groups = [{'race': 0}]  # African-American
+
+# Split into train/test
+train, test = dataset.split([0.7], shuffle=True)
+
+# Train a simple logistic regression model
+X_train = train.features
+y_train = train.labels.ravel()
+
+lr = LogisticRegression(solver='liblinear')
+lr.fit(X_train, y_train)
+
+# Predict on test set
+test_pred = test.copy()
+test_pred.labels = lr.predict(test.features).reshape(-1, 1)
+
+# Evaluate fairness metrics
+classified_metric = ClassificationMetric(
+    test, test_pred,
+    unprivileged_groups=unprivileged_groups,
+    privileged_groups=privileged_groups
+)
+
+# Extract False Positive Rate
+fpr_unpriv = classified_metric.false_positive_rate(unprivileged=True)
+fpr_priv = classified_metric.false_positive_rate(unprivileged=False)
+
+# Visualization
+plt.bar(['African-American', 'Caucasian'], [fpr_unpriv, fpr_priv], color=['red', 'blue'])
+plt.title('False Positive Rate by Race')
+plt.ylabel('False Positive Rate')
+plt.show()


### PR DESCRIPTION
PART 3
Overview
This audit assessed racial bias in the COMPAS Recidivism Dataset using IBM’s AI Fairness 360 toolkit. The COMPAS dataset contains criminal history, jail, and demographic data, used to predict recidivism risk. The primary concern is whether risk scores disproportionately misclassify African-American individuals compared to Caucasians.

Methodology
Using a simple logistic regression model trained on 70% of the dataset, we tested the model's predictions on the remaining 30%. We evaluated fairness using key metrics provided by AI Fairness 360, particularly focusing on False Positive Rate (FPR) across racial groups. The privileged group was defined as Caucasians, and the unprivileged group as African-Americans.

Findings
The analysis revealed a significantly higher false positive rate for African-American individuals compared to Caucasian counterparts. This implies that African-Americans were more likely to be incorrectly predicted as high risk for recidivism. This kind of disparate impact raises ethical concerns, particularly in judicial decisions where fairness and equity are paramount.

Remediation Steps
To mitigate the bias, we recommend implementing pre-processing bias mitigation techniques such as Reweighing, which adjusts weights of training samples to balance representation across groups. Additionally, post-processing techniques like Equalized Odds or Reject Option Classification can be applied after model training to correct for biased predictions.

Furthermore, retraining models on balanced datasets and including more representative features (like socioeconomic indicators) could enhance fairness. Regular fairness audits should be embedded in the AI lifecycle to ensure continued accountability.

Conclusion
The COMPAS dataset demonstrates clear racial disparities in predictive performance. Without mitigation, such models risk perpetuating systemic injustices. Ethical AI development requires both technical interventions and policy oversight to ensure equitable outcomes for all populations.
